### PR TITLE
Prevent devtools to open in docked state by default

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -109,7 +109,7 @@ ipcMain.on('open-route', (event, route) => {
                 show: false
             });
             childs[route].removeMenu();
-            
+
             loadApp(childs[route], `#/${route}`);
 
             childs[route].once('ready-to-show', () => {
@@ -149,7 +149,7 @@ function loadApp(win: BrowserWindow, route: string = '') {
     }
 
     if (serve) {
-        win.webContents.openDevTools();
+        win.webContents.openDevTools({mode: 'undocked'});
     }
 }
 


### PR DESCRIPTION
I tried to run the project locally, but had the following problem. The docked devtools window of the main overlay window wasn't clickable and always on top.

Opening the devtools in an undocked state solves this issue. I just want to make it easier for other devs to get started.