### PR TITLE
feat(accelerator): add support for ` < and |

### DIFF
--- a/src/app/shared/module/material/component/accelerator/accelerator.component.ts
+++ b/src/app/shared/module/material/component/accelerator/accelerator.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
 /* tslint:disable */
-const KEY_CODES = /^(F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|[0-9A-Z]|\`)$/;
+const KEY_CODES = /^(F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|[0-9A-Z]|[`|<])$/;
 /* tslint:enable */
 
 const PRESERVERED_ACCELERATORS = [

--- a/src/app/shared/module/material/component/accelerator/accelerator.component.ts
+++ b/src/app/shared/module/material/component/accelerator/accelerator.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
 /* tslint:disable */
-const KEY_CODES = /^(F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|[0-9A-Z])$/;
+const KEY_CODES = /^(F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|[0-9A-Z]|\`)$/;
 /* tslint:enable */
 
 const PRESERVERED_ACCELERATORS = [


### PR DESCRIPTION
Added the ` character to the `KEY_CODES` of the accelerator.  This will allow users to bind the button on the left of 1 to commands.  (I've only added ` since this is the char used by LutBot (logout script).

![image](https://user-images.githubusercontent.com/11649822/76342623-4695cd00-62d5-11ea-8603-8a1a6b591658.png)
