### PR TITLE
Feature/poe.ninja filter by item name

### DIFF
--- a/src/app/data/poe-ninja/service/currency-overview-http.service.spec.ts
+++ b/src/app/data/poe-ninja/service/currency-overview-http.service.spec.ts
@@ -3,39 +3,36 @@ import { HttpClientModule } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import { AssetService } from '@app/assets';
-import { CurrencyOverviewHttpService } from './currency-overview-http.service';
 import { TradeLeaguesHttpLeague } from '@data/poe/schema';
+import { CurrencyOverviewHttpService } from './currency-overview-http.service';
 
-
-
-fdescribe('CurrencyOverviewHttpService', () => {
+describe('CurrencyOverviewHttpService', () => {
   let sut: CurrencyOverviewHttpService;
 
   beforeEach(async () => {
-        TestBed.configureTestingModule({
-            imports: [
-                CommonModule,
-                HttpClientModule,
-                BrowserModule
-            ]
-        }).compileComponents();
-        sut = TestBed.inject<CurrencyOverviewHttpService>(CurrencyOverviewHttpService);
-        const asset = TestBed.inject<AssetService>(AssetService);
-        await asset.load().toPromise();
-    });
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        HttpClientModule,
+        BrowserModule
+      ]
+    }).compileComponents();
+    sut = TestBed.inject<CurrencyOverviewHttpService>(CurrencyOverviewHttpService);
+    const asset = TestBed.inject<AssetService>(AssetService);
+    await asset.load().toPromise();
+  });
 
   const leagueMap = {
-      [TradeLeaguesHttpLeague.Standard]: 'standard',
-      [TradeLeaguesHttpLeague.HardCore]: 'hardcore',
-      ['Harvest']: 'challenge',
-      ['Hardcore Harvest']: 'challengehc',
+    [TradeLeaguesHttpLeague.Standard]: 'standard',
+    [TradeLeaguesHttpLeague.Hardcore]: 'hardcore',
+    ['Harvest']: 'challenge',
+    ['Hardcore Harvest']: 'challengehc',
   };
 
   Object.keys(leagueMap).forEach(key => {
-      it(`getLeaguePath('${key}') should be '${leagueMap[key]}'`, () => {
-        const result = sut["getLeaguePath"](key);
-        expect(result).toBe(leagueMap[key]);
-      });
-    }
-  );
+    it(`getLeaguePath('${key}') should be '${leagueMap[key]}'`, () => {
+      const result = sut.getLeaguePath(key);
+      expect(result).toBe(leagueMap[key]);
+    });
+  });
 });

--- a/src/app/data/poe-ninja/service/currency-overview-http.service.spec.ts
+++ b/src/app/data/poe-ninja/service/currency-overview-http.service.spec.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { AssetService } from '@app/assets';
+import { CurrencyOverviewHttpService } from './currency-overview-http.service';
+import { TradeLeaguesHttpLeague } from '@data/poe/schema';
+
+
+
+fdescribe('CurrencyOverviewHttpService', () => {
+  let sut: CurrencyOverviewHttpService;
+
+  beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [
+                CommonModule,
+                HttpClientModule,
+                BrowserModule
+            ]
+        }).compileComponents();
+        sut = TestBed.inject<CurrencyOverviewHttpService>(CurrencyOverviewHttpService);
+        const asset = TestBed.inject<AssetService>(AssetService);
+        await asset.load().toPromise();
+    });
+
+  const leagueMap = {
+      [TradeLeaguesHttpLeague.Standard]: 'standard',
+      [TradeLeaguesHttpLeague.HardCore]: 'hardcore',
+      ['Harvest']: 'challenge',
+      ['Hardcore Harvest']: 'challengehc',
+  };
+
+  Object.keys(leagueMap).forEach(key => {
+      it(`getLeaguePath('${key}') should be '${leagueMap[key]}'`, () => {
+        const result = sut["getLeaguePath"](key);
+        expect(result).toBe(leagueMap[key]);
+      });
+    }
+  );
+});

--- a/src/app/data/poe-ninja/service/currency-overview-http.service.ts
+++ b/src/app/data/poe-ninja/service/currency-overview-http.service.ts
@@ -5,6 +5,7 @@ import { environment } from '@env/environment';
 import { Observable, of, throwError } from 'rxjs';
 import { delay, flatMap, retryWhen } from 'rxjs/operators';
 import { CurrencyOverviewResponse } from '../schema/currency-overview';
+import { OverviewHttpService } from './overview-http.service';
 
 export enum CurrencyOverviewType {
     Currency = 'Currency',
@@ -22,11 +23,13 @@ const RETRY_DELAY = 100;
 @Injectable({
     providedIn: 'root'
 })
-export class CurrencyOverviewHttpService {
+export class CurrencyOverviewHttpService extends OverviewHttpService {
     private readonly baseUrl: string;
 
     constructor(
-        private readonly httpClient: HttpClient) {
+        private readonly httpClient: HttpClient
+    ) {
+        super();
         this.baseUrl = `${environment.poeNinja.baseUrl}/api/data/currencyoverview`;
     }
 
@@ -64,21 +67,5 @@ export class CurrencyOverviewHttpService {
 
     private getUrl(leagueId: string, type: CurrencyOverviewType): string {
         return `${this.baseUrl}?league=${encodeURIComponent(leagueId)}&type=${encodeURIComponent(type)}&language=en`;
-    }
-
-    private getLeaguePath(leagueId: string): string {
-        switch (leagueId) {
-            case TradeLeaguesHttpLeague.Standard:
-                return 'standard';
-            case TradeLeaguesHttpLeague.HardCore:
-                return 'hardcore';
-        }
-
-        const exp = new RegExp(`${TradeLeaguesHttpLeague.HardCore} .*`);
-        const regexResult = exp.exec(leagueId);
-        if (regexResult !== null) {
-            return 'challengehc';
-        }
-        return 'challenge';
     }
 }

--- a/src/app/data/poe-ninja/service/currency-overview-http.service.ts
+++ b/src/app/data/poe-ninja/service/currency-overview-http.service.ts
@@ -48,7 +48,7 @@ export class CurrencyOverviewHttpService {
 
                 const result: CurrencyOverviewResponse = {
                     lines: response.lines,
-                    url: `${environment.poeNinja.baseUrl}/challenge/${PATH_TYPE_MAP[type]}`
+                    url: `${environment.poeNinja.baseUrl}/${this.getLeaguePath(leagueId)}/${PATH_TYPE_MAP[type]}`
                 };
                 return of(result);
             })
@@ -64,5 +64,21 @@ export class CurrencyOverviewHttpService {
 
     private getUrl(leagueId: string, type: CurrencyOverviewType): string {
         return `${this.baseUrl}?league=${encodeURIComponent(leagueId)}&type=${encodeURIComponent(type)}&language=en`;
+    }
+
+    private getLeaguePath(leagueId: string): string {
+        switch (leagueId) {
+            case TradeLeaguesHttpLeague.Standard:
+                return 'standard';
+            case TradeLeaguesHttpLeague.HardCore:
+                return 'hardcore';
+        }
+
+        const exp = new RegExp(`${TradeLeaguesHttpLeague.HardCore} .*`);
+        const regexResult = exp.exec(leagueId);
+        if (regexResult !== null) {
+            return 'challengehc';
+        }
+        return 'challenge';
     }
 }

--- a/src/app/data/poe-ninja/service/item-overview-http.service.spec.ts
+++ b/src/app/data/poe-ninja/service/item-overview-http.service.spec.ts
@@ -3,39 +3,36 @@ import { HttpClientModule } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { BrowserModule } from '@angular/platform-browser';
 import { AssetService } from '@app/assets';
-import { ItemOverviewHttpService } from './item-overview-http.service';
 import { TradeLeaguesHttpLeague } from '@data/poe/schema';
+import { ItemOverviewHttpService } from './item-overview-http.service';
 
-
-
-fdescribe('ItemOverviewHttpService', () => {
+describe('ItemOverviewHttpService', () => {
   let sut: ItemOverviewHttpService;
 
   beforeEach(async () => {
-        TestBed.configureTestingModule({
-            imports: [
-                CommonModule,
-                HttpClientModule,
-                BrowserModule
-            ]
-        }).compileComponents();
-        sut = TestBed.inject<ItemOverviewHttpService>(ItemOverviewHttpService);
-        const asset = TestBed.inject<AssetService>(AssetService);
-        await asset.load().toPromise();
-    });
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        HttpClientModule,
+        BrowserModule
+      ]
+    }).compileComponents();
+    sut = TestBed.inject<ItemOverviewHttpService>(ItemOverviewHttpService);
+    const asset = TestBed.inject<AssetService>(AssetService);
+    await asset.load().toPromise();
+  });
 
   const leagueMap = {
-      [TradeLeaguesHttpLeague.Standard]: 'standard',
-      [TradeLeaguesHttpLeague.HardCore]: 'hardcore',
-      ['Harvest']: 'challenge',
-      ['Hardcore Harvest']: 'challengehc',
+    [TradeLeaguesHttpLeague.Standard]: 'standard',
+    [TradeLeaguesHttpLeague.Hardcore]: 'hardcore',
+    ['Harvest']: 'challenge',
+    ['Hardcore Harvest']: 'challengehc',
   };
 
   Object.keys(leagueMap).forEach(key => {
-      it(`getLeaguePath('${key}') should be '${leagueMap[key]}'`, () => {
-        const result = sut["getLeaguePath"](key);
-        expect(result).toBe(leagueMap[key]);
-      });
-    }
-  );
+    it(`getLeaguePath('${key}') should be '${leagueMap[key]}'`, () => {
+      const result = sut.getLeaguePath(key);
+      expect(result).toBe(leagueMap[key]);
+    });
+  });
 });

--- a/src/app/data/poe-ninja/service/item-overview-http.service.spec.ts
+++ b/src/app/data/poe-ninja/service/item-overview-http.service.spec.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { BrowserModule } from '@angular/platform-browser';
+import { AssetService } from '@app/assets';
+import { ItemOverviewHttpService } from './item-overview-http.service';
+import { TradeLeaguesHttpLeague } from '@data/poe/schema';
+
+
+
+fdescribe('ItemOverviewHttpService', () => {
+  let sut: ItemOverviewHttpService;
+
+  beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [
+                CommonModule,
+                HttpClientModule,
+                BrowserModule
+            ]
+        }).compileComponents();
+        sut = TestBed.inject<ItemOverviewHttpService>(ItemOverviewHttpService);
+        const asset = TestBed.inject<AssetService>(AssetService);
+        await asset.load().toPromise();
+    });
+
+  const leagueMap = {
+      [TradeLeaguesHttpLeague.Standard]: 'standard',
+      [TradeLeaguesHttpLeague.HardCore]: 'hardcore',
+      ['Harvest']: 'challenge',
+      ['Hardcore Harvest']: 'challengehc',
+  };
+
+  Object.keys(leagueMap).forEach(key => {
+      it(`getLeaguePath('${key}') should be '${leagueMap[key]}'`, () => {
+        const result = sut["getLeaguePath"](key);
+        expect(result).toBe(leagueMap[key]);
+      });
+    }
+  );
+});

--- a/src/app/data/poe-ninja/service/item-overview-http.service.ts
+++ b/src/app/data/poe-ninja/service/item-overview-http.service.ts
@@ -78,7 +78,7 @@ export class ItemOverviewHttpService {
 
                 const result: ItemOverviewResponse = {
                     lines: response.lines,
-                    url: `${environment.poeNinja.baseUrl}/challenge/${PATH_TYPE_MAP[type]}`
+                    url: `${environment.poeNinja.baseUrl}/${this.getLeaguePath(leagueId)}/${PATH_TYPE_MAP[type]}`
                 };
                 return of(result);
             })
@@ -94,5 +94,21 @@ export class ItemOverviewHttpService {
 
     private getUrl(leagueId: string, type: ItemOverviewType): string {
         return `${this.baseUrl}?league=${encodeURIComponent(leagueId)}&type=${encodeURIComponent(type)}&language=en`;
+    }
+
+    private getLeaguePath(leagueId: string): string {
+        switch (leagueId) {
+            case TradeLeaguesHttpLeague.Standard:
+                return 'standard';
+            case TradeLeaguesHttpLeague.HardCore:
+                return 'hardcore';
+        }
+
+        const exp = new RegExp(`${TradeLeaguesHttpLeague.HardCore} .*`);
+        const regexResult = exp.exec(leagueId);
+        if (regexResult !== null) {
+            return 'challengehc';
+        }
+        return 'challenge';
     }
 }

--- a/src/app/data/poe-ninja/service/item-overview-http.service.ts
+++ b/src/app/data/poe-ninja/service/item-overview-http.service.ts
@@ -5,6 +5,7 @@ import { environment } from '@env/environment';
 import { Observable, of, throwError } from 'rxjs';
 import { delay, flatMap, retryWhen } from 'rxjs/operators';
 import { ItemOverviewResponse } from '../schema/item-overview';
+import { OverviewHttpService } from './overview-http.service';
 
 export enum ItemOverviewType {
     Prophecy = 'Prophecy',
@@ -52,11 +53,13 @@ const RETRY_DELAY = 100;
 @Injectable({
     providedIn: 'root'
 })
-export class ItemOverviewHttpService {
+export class ItemOverviewHttpService extends OverviewHttpService {
     private readonly baseUrl: string;
 
     constructor(
-        private readonly httpClient: HttpClient) {
+        private readonly httpClient: HttpClient
+    ) {
+        super();
         this.baseUrl = `${environment.poeNinja.baseUrl}/api/data/itemoverview`;
     }
 
@@ -94,21 +97,5 @@ export class ItemOverviewHttpService {
 
     private getUrl(leagueId: string, type: ItemOverviewType): string {
         return `${this.baseUrl}?league=${encodeURIComponent(leagueId)}&type=${encodeURIComponent(type)}&language=en`;
-    }
-
-    private getLeaguePath(leagueId: string): string {
-        switch (leagueId) {
-            case TradeLeaguesHttpLeague.Standard:
-                return 'standard';
-            case TradeLeaguesHttpLeague.HardCore:
-                return 'hardcore';
-        }
-
-        const exp = new RegExp(`${TradeLeaguesHttpLeague.HardCore} .*`);
-        const regexResult = exp.exec(leagueId);
-        if (regexResult !== null) {
-            return 'challengehc';
-        }
-        return 'challenge';
     }
 }

--- a/src/app/data/poe-ninja/service/overview-http.service.ts
+++ b/src/app/data/poe-ninja/service/overview-http.service.ts
@@ -1,0 +1,18 @@
+import { TradeLeaguesHttpLeague } from '@data/poe/schema';
+
+export abstract class OverviewHttpService {
+    protected getLeaguePath(leagueId: string): string {
+        switch (leagueId) {
+            case TradeLeaguesHttpLeague.Standard:
+                return 'standard';
+            case TradeLeaguesHttpLeague.Hardcore:
+                return 'hardcore';
+            default:
+                const exp = new RegExp(`${TradeLeaguesHttpLeague.Hardcore} .*`);
+                if (exp.exec(leagueId)) {
+                    return 'challengehc';
+                }
+                return 'challenge';
+        }
+    }
+}

--- a/src/app/data/poe/schema/trade-leagues.ts
+++ b/src/app/data/poe/schema/trade-leagues.ts
@@ -2,7 +2,7 @@ import { TradeHttpResponse } from './trade';
 
 export enum TradeLeaguesHttpLeague {
     Standard = 'Standard',
-    HardCore = 'Hardcore',
+    Hardcore = 'Hardcore',
 }
 
 export interface TradeLeaguesHttpResult {

--- a/src/app/data/poe/schema/trade-leagues.ts
+++ b/src/app/data/poe/schema/trade-leagues.ts
@@ -2,6 +2,7 @@ import { TradeHttpResponse } from './trade';
 
 export enum TradeLeaguesHttpLeague {
     Standard = 'Standard',
+    HardCore = 'Hardcore',
 }
 
 export interface TradeLeaguesHttpResult {

--- a/src/app/shared/module/poe/price/item-price-rates.provider.ts
+++ b/src/app/shared/module/poe/price/item-price-rates.provider.ts
@@ -170,7 +170,7 @@ export class ItemPriceRatesProvider {
                         change: sparkLine.totalChange,
                         history: sparkLine.data,
                         chaosAmount: line.chaosEquivalent,
-                        url: response.url
+                        url: response.url + this.getUrlSuffix(line.currencyTypeName)
                     };
                     return rate;
                 })
@@ -199,7 +199,7 @@ export class ItemPriceRatesProvider {
                         change: sparkLine.totalChange,
                         history: sparkLine.data,
                         chaosAmount: line.chaosValue,
-                        url: response.url
+                        url: response.url + this.getUrlSuffix(line.name)
                     };
                     return rate;
                 })
@@ -207,4 +207,9 @@ export class ItemPriceRatesProvider {
             return result;
         }));
     }
+
+    private getUrlSuffix(name: string): string {
+        return `?name=${encodeURIComponent(name)}`;
+    }
+
 }

--- a/src/app/shared/module/poe/price/item-price-rates.provider.ts
+++ b/src/app/shared/module/poe/price/item-price-rates.provider.ts
@@ -135,9 +135,9 @@ export class ItemPriceRatesProvider {
             case ItemCategory.GemActivegem:
             case ItemCategory.GemSupportGem:
             case ItemCategory.GemSupportGemplus: {
-                    const key = `${leagueId}_${ItemCategory.Gem}`;
-                    return this.fetch(key, () => this.fetchItem(leagueId, ItemOverviewType.SkillGem));
-                }
+                const key = `${leagueId}_${ItemCategory.Gem}`;
+                return this.fetch(key, () => this.fetchItem(leagueId, ItemOverviewType.SkillGem));
+            }
             case ItemCategory.MapScarab:
             case ItemCategory.Leaguestone:
             case ItemCategory.MonsterSample:
@@ -170,7 +170,7 @@ export class ItemPriceRatesProvider {
                         change: sparkLine.totalChange,
                         history: sparkLine.data,
                         chaosAmount: line.chaosEquivalent,
-                        url: response.url + this.getUrlSuffix(line.currencyTypeName)
+                        url: `${response.url}${this.getUrlSuffix(line.currencyTypeName)}`
                     };
                     return rate;
                 })
@@ -199,7 +199,7 @@ export class ItemPriceRatesProvider {
                         change: sparkLine.totalChange,
                         history: sparkLine.data,
                         chaosAmount: line.chaosValue,
-                        url: response.url + this.getUrlSuffix(line.name)
+                        url: `${response.url}${this.getUrlSuffix(line.name)}`
                     };
                     return rate;
                 })
@@ -211,5 +211,4 @@ export class ItemPriceRatesProvider {
     private getUrlSuffix(name: string): string {
         return `?name=${encodeURIComponent(name)}`;
     }
-
 }

--- a/src/app/shared/module/poe/trade/chat/trade-chat-parser.service.spec.ts
+++ b/src/app/shared/module/poe/trade/chat/trade-chat-parser.service.spec.ts
@@ -6,7 +6,7 @@ import { AssetService } from '@app/assets';
 import { TradeChatParserService } from '.';
 import { TradeParserType } from './trade-chat';
 
-fdescribe('TradeChatParserService', () => {
+describe('TradeChatParserService', () => {
     let sut: TradeChatParserService;
     beforeEach(async () => {
         TestBed.configureTestingModule({


### PR DESCRIPTION
This PR fixes #208

and add filter by league of poe.ninja

all league
before: https://poe.ninja/challenge/currency

after:
 standard: https://poe.ninja/standard/currency
 hardcore: https://poe.ninja/hardcore/currency
 hardcore .*: https://poe.ninja/challengehc/currency
 others: https://poe.ninja/challenge/currency

Please tell me if something is wrong