### PR TITLE
added a whois button at the trade menu

### DIFF
--- a/src/app/modules/trade/class/trade-message-action.ts
+++ b/src/app/modules/trade/class/trade-message-action.ts
@@ -8,7 +8,8 @@ export enum TradeMessageAction {
     ItemHighlight = 'item-highlight',
     Whisper = 'whisper',
     Finished = 'finished',
-    Hideout = 'hideout'
+    Hideout = 'hideout',
+    Whois = 'whois'
 }
 
 export interface TradeMessageActionState {

--- a/src/app/modules/trade/component/trade-message-action/trade-message-action.component.html
+++ b/src/app/modules/trade/component/trade-message-action/trade-message-action.component.html
@@ -12,6 +12,6 @@
         <mat-icon *ngSwitchCase="'dismiss'">close</mat-icon>
         <mat-icon *ngSwitchCase="'interested'">hearing</mat-icon>
         <mat-icon *ngSwitchCase="'hideout'">exit_to_app</mat-icon>
-        <mat-icon *ngSwitchCase="'whois'">person</mat-icon>
+        <mat-icon *ngSwitchCase="'whois'">person_search</mat-icon>
     </ng-container>
 </button>

--- a/src/app/modules/trade/component/trade-message-action/trade-message-action.component.html
+++ b/src/app/modules/trade/component/trade-message-action/trade-message-action.component.html
@@ -12,5 +12,6 @@
         <mat-icon *ngSwitchCase="'dismiss'">close</mat-icon>
         <mat-icon *ngSwitchCase="'interested'">hearing</mat-icon>
         <mat-icon *ngSwitchCase="'hideout'">exit_to_app</mat-icon>
+        <mat-icon *ngSwitchCase="'whois'">person</mat-icon>
     </ng-container>
 </button>

--- a/src/app/modules/trade/component/trade-message/trade-message.component.html
+++ b/src/app/modules/trade/component/trade-message/trade-message.component.html
@@ -29,6 +29,9 @@
         <app-trade-message-action action="resend" [visible]="visible" [title]="' @' + message.name"
             (execute)="onActionExecute($event)">
         </app-trade-message-action>
+        <app-trade-message-action action="whois" [visible]="visible" [title]="' @' + message.name"
+            (execute)="onActionExecute($event)">
+        </app-trade-message-action>
         <app-trade-message-action action="whisper" [visible]="visible"
             [title]="' @' + message.name + (message.whispers$ | async | tradeWhisperTitle)"
             (execute)="onActionExecute($event)">
@@ -49,9 +52,6 @@
             (execute)="onActionExecute($event)">
         </app-trade-message-action>
         <app-trade-message-action action="item-gone" [visible]="visible" [title]="' @' + message.name"
-            (execute)="onActionExecute($event)">
-        </app-trade-message-action>
-        <app-trade-message-action action="whois" [visible]="visible" [title]="' @' + message.name"
             (execute)="onActionExecute($event)">
         </app-trade-message-action>
     </div>

--- a/src/app/modules/trade/component/trade-message/trade-message.component.html
+++ b/src/app/modules/trade/component/trade-message/trade-message.component.html
@@ -51,6 +51,9 @@
         <app-trade-message-action action="item-gone" [visible]="visible" [title]="' @' + message.name"
             (execute)="onActionExecute($event)">
         </app-trade-message-action>
+        <app-trade-message-action action="whois" [visible]="visible" [title]="' @' + message.name"
+            (execute)="onActionExecute($event)">
+        </app-trade-message-action>
     </div>
     <div class="dismiss">
         <div class="poe-close" (click)="onDismiss()"></div>

--- a/src/app/modules/trade/component/trade-message/trade-message.component.ts
+++ b/src/app/modules/trade/component/trade-message/trade-message.component.ts
@@ -51,6 +51,7 @@ export class TradeMessageComponent implements OnInit {
     this.visible[TradeMessageAction.Invite] = true;
     this.visible[TradeMessageAction.Trade] = true;
     this.visible[TradeMessageAction.Whisper] = true;
+    this.visible[TradeMessageAction.Whois] = true;
     if (this.message.direction === TradeWhisperDirection.Incoming) {
       this.visible[TradeMessageAction.Wait] = true;
       this.visible[TradeMessageAction.Interested] = true;
@@ -127,6 +128,9 @@ export class TradeMessageComponent implements OnInit {
         break;
       case TradeMessageAction.Hideout:
         this.chat.hideout(this.message.name);
+        break;
+      case TradeMessageAction.Whois:
+        this.chat.whois(this.message.name);
         break;
     }
   }

--- a/src/app/shared/module/poe/chat/chat.service.ts
+++ b/src/app/shared/module/poe/chat/chat.service.ts
@@ -72,6 +72,11 @@ export class ChatService {
         this.queue$.next({ message, send: true });
     }
 
+    public whois(name: string): void {
+        const message = this.generateMessage('/whois', name);
+        this.queue$.next({ message, send: true });
+    }
+
     private init(): void {
         this.queue$.pipe(
             windowTime(350),


### PR DESCRIPTION
This PR fixes #803 

Hi, Thank you for the review last time.
This time I did "yarn lint".

I have 4 questions.

The "whois" icon was created with reference to "Mercury Trade".
Is the icon okay ... ?
Where should I place it?
![image](https://user-images.githubusercontent.com/42040439/89038757-e4209480-d37b-11ea-8686-e0bcd7d386b7.png)

Does the expected behavior match the image below?
![image](https://user-images.githubusercontent.com/42040439/89038858-0dd9bb80-d37c-11ea-8bf4-62fe26898ac1.png)

Or this?
![image](https://user-images.githubusercontent.com/42040439/89038874-18945080-d37c-11ea-9646-f0ddc3d241b4.png)